### PR TITLE
export first rdata result as a label

### DIFF
--- a/dns/exporter.go
+++ b/dns/exporter.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"strconv"
 
 	"github.com/DNS-OARC/ripeatlas/measurement"
@@ -56,7 +57,12 @@ func (m *dnsExporter) Export(res *measurement.Result, probe *probe.Probe, ch cha
 		for _, s := range opt.Option {
 			switch e := s.(type) {
 			case *mdns.EDNS0_NSID:
-				nsid = e.Nsid
+				b := []byte(e.Nsid)
+				dst := make([]byte, hex.DecodedLen(len(b)))
+				_, err := hex.Decode(dst, b)
+				if err == nil {
+					nsid = string(dst)
+				}
 			}
 		}
 	}

--- a/dns/exporter.go
+++ b/dns/exporter.go
@@ -1,11 +1,13 @@
 package dns
 
 import (
+	"encoding/base64"
 	"strconv"
 
 	"github.com/DNS-OARC/ripeatlas/measurement"
 	"github.com/DNS-OARC/ripeatlas/measurement/dns"
 	"github.com/czerwonk/atlas_exporter/probe"
+	mdns "github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -16,7 +18,7 @@ var (
 )
 
 func init() {
-	labels = []string{"measurement", "probe", "dst_addr", "asn", "ip_version", "country_code", "lat", "long", "rdata1"}
+	labels = []string{"measurement", "probe", "dst_addr", "asn", "ip_version", "country_code", "lat", "long", "rdata1", "nsid"}
 
 	successDesc = prometheus.NewDesc(prometheus.BuildFQName(ns, sub, "success"), "Destination was reachable", labels, nil)
 	rttDesc = prometheus.NewDesc(prometheus.BuildFQName(ns, sub, "rtt"), "Roundtrip time in ms", labels, nil)
@@ -30,15 +32,32 @@ type dnsExporter struct {
 func (m *dnsExporter) Export(res *measurement.Result, probe *probe.Probe, ch chan<- prometheus.Metric) {
 	var rtt float64
 	var answers []*dns.Answer
+	var abuf string
 	if res.DnsResult() != nil {
 		rtt = res.DnsResult().Rt()
 		answers = res.DnsResult().Answers()
+		abuf = res.DnsResult().Abuf()
 	}
 
 	var rdata1 string
 	if len(answers) > 0 {
 		if len(answers[0].Rdata()) > 0 {
 			rdata1 = answers[0].Rdata()[0]
+		}
+	}
+
+	var nsid string
+	var msg mdns.Msg
+	decoded, _ := base64.StdEncoding.DecodeString(abuf)
+	err := msg.Unpack(decoded)
+
+	if err == nil {
+		opt := msg.IsEdns0()
+		for _, s := range opt.Option {
+			switch e := s.(type) {
+			case *mdns.EDNS0_NSID:
+				nsid = e.Nsid
+			}
 		}
 	}
 
@@ -52,6 +71,7 @@ func (m *dnsExporter) Export(res *measurement.Result, probe *probe.Probe, ch cha
 		probe.Latitude(),
 		probe.Longitude(),
 		rdata1,
+		nsid,
 	}
 
 	if rtt > 0 {


### PR DESCRIPTION
This adds an additional label to exported DNS metrics for including the first RDATA result. This PR doesn't need to and likely shouldn't merge. This was done to solve a specific use case and the attached patch can be applied to any fork that requires this label/data.

Added an additional commit to also process the abuf result to retrieve the NSID as an additional label.

Patch: 
[export_rdata_nsid.patch.zip](https://github.com/czerwonk/atlas_exporter/files/4773200/export_rdata_nsid.patch.zip)

